### PR TITLE
26: Discover per project commands.

### DIFF
--- a/bin/chirripo.php
+++ b/bin/chirripo.php
@@ -6,21 +6,7 @@ if (\file_exists(__DIR__ . '/../vendor/autoload.php')) {
 }
 
 use Symfony\Component\Console\Application;
-use Console\App\Commands\DockerComposeCommand;
-use Console\App\Commands\StartCommand;
-use Console\App\Commands\StopCommand;
-use Console\App\Commands\DownCommand;
-use Console\App\Commands\SshCommand;
-use Console\App\Commands\StatusCommand;
-use Console\App\Commands\RestartCommand;
-use Console\App\Commands\DockerLogsCommand;
-use Console\App\Commands\UrlCommand;
-use Console\App\Commands\DrushCommand;
-use Console\App\Commands\MysqlCommand;
-use Console\App\Commands\DbImportCommand;
-use Console\App\Commands\PhpModulesCommand;
-use Console\App\Commands\PhpInfoCommand;
-use Console\App\Commands\PrintHostsEntries;
+use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 
 define('CHIRRIPO_VERSION', '1.0');
 
@@ -37,21 +23,25 @@ function chirripo_version() {
 function chirripo_main() {
     $app = new Application();
     $app->setName('Chirripo CLI Tool');
-    $app->add(new DockerComposeCommand());
-    $app->add(new StartCommand());
-    $app->add(new StopCommand());
-    $app->add(new DownCommand());
-    $app->add(new SshCommand());
-    $app->add(new RestartCommand());
-    $app->add(new StatusCommand());
-    $app->add(new DockerLogsCommand());
-    $app->add(new UrlCommand());
-    $app->add(new DrushCommand());
-    $app->add(new MysqlCommand());
-    $app->add(new DbImportCommand());
-    $app->add(new PhpModulesCommand());
-    $app->add(new PhpInfoCommand());
-    $app->add(new PrintHostsEntries());
+
+    $chirripo_directory = __DIR__ . '/../src/App/Commands';
+    $chirripo_project_directory = __DIR__ . '/../../../../chirripo/App/Commands';
+
+    $discovery = new CommandFileDiscovery();
+    $discovery->setSearchPattern('*Command.php');
+    $defaultCommandClasses = $discovery->discover("{$chirripo_directory}/", 'Console\App\Commands');
+
+    $customCommandClasses = [];
+    if (file_exists("{$chirripo_project_directory}/")) {
+        $customCommandClasses = $discovery->discover("{$chirripo_project_directory}/", '\\Console\App\Commands');
+    }
+
+    $commandClasses = array_merge($defaultCommandClasses, $customCommandClasses);
+
+    foreach ($commandClasses as $file => $class) {
+        require_once($file);
+        $app->add(new $class());
+    }
 
     $app->run();
 }

--- a/src/App/Commands/PrintHostsEntriesCommand.php
+++ b/src/App/Commands/PrintHostsEntriesCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 /**
  * Url Command class.
  */
-class PrintHostsEntries extends Command
+class PrintHostsEntriesCommand extends Command
 {
     use ChirripoCommandTrait;
 


### PR DESCRIPTION
<!--- Please use this template when creating a Pull Request. **Delete this section** and fill in the rest of the template below, deleting the commented sections -->
<!--- It's asked that every Pull Request has associated an issue for the initial discussion -->

## Issue Reference

Issue Number: #26 

## What does this Pull Request do?

Add per-project commands support

## How can this Pull Request be tested?

Add a new command like this under your project root in folder: chirripo/App/Commands. File name (and class) must end with Command

```
<?php

namespace Console\App\Commands;

use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Process\Process;
use Symfony\Component\Process\Exception\ProcessFailedException;

/**
 * Docker Logs Command class.
 */
class TestCommand extends Command
{
    use ChirripoCommandTrait;

    protected function configure()
    {
        $this->setName('test')
            ->setDescription('Execute chirripo test command');
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $this->setupEnv();
        $output->writeln(sprintf("Executing: chirripo test"));

        $files = $this->setupFiles();

        $command = ['chirripo', 'dc', 'ps'];
        $docker_root = __DIR__ . '/../../../docker';
        $process = new Process($command, $docker_root);
        $process->setTimeout(300);
        $process->run();

        // Executes after the command finishes.
        if (!$process->isSuccessful()) {
            $output->writeln(sprintf(
                "\n\nOutput:\n================\n%s\n\nError Output:\n================\n%s",
                $process->getOutput(),
                $process->getErrorOutput()
            ));
            exit(1);
        }

        echo $process->getOutput();
    }
}
```

Run `chirripo list`

Your test command (`chirripo test`) must be available.

## Any additional notes/comments?

Documentation should be added to chirripo/docs right after merging this PR