### PR TITLE
Hotfix: adding missing 's' for the remove-orphan option into the start command

### DIFF
--- a/src/App/Commands/StartCommand.php
+++ b/src/App/Commands/StartCommand.php
@@ -39,7 +39,7 @@ class StartCommand extends Command
                 'create',
                 'chirripo_proxy',
             ],
-            array_merge(['docker-compose', '-p', $_ENV['PROJECT_NAME']], $files, ['up', '-d', '--remove-orphan']),
+            array_merge(['docker-compose', '-p', $_ENV['PROJECT_NAME']], $files, ['up', '-d', '--remove-orphans']),
             [
                 'docker',
                 'cp',


### PR DESCRIPTION


<!--- Please use this template when creating a Pull Request. **Delete this section** and fill in the rest of the template below, deleting the commented sections -->
<!--- It's asked that every Pull Request has associated an issue for the initial discussion -->

## Issue Reference

Issue Number: #44 

## What does this Pull Request do?
Fix issue with docker-compose 2 and the remove-orphan option

## How can this Pull Request be tested?
Install the latest version docker for mac and generate a new project and try to start it up, it should fail.

## Any additional notes/comments?
Look at the referenced issue for more info