### PR TITLE
Feature: Update composer for code deprecated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     },
     "bin": ["bin/chirripo"],
     "require": {
-        "symfony/console": ">=5.4",
-        "symfony/process": ">=3.4",
+        "symfony/console": ">=4.4",
+        "symfony/process": ">=4.4",
         "symfony/dotenv": ">=3.4",
         "consolidation/robo": ">=1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "bin": ["bin/chirripo"],
     "require": {
-        "symfony/console": ">=3.4",
+        "symfony/console": ">=5.4",
         "symfony/process": ">=3.4",
         "symfony/dotenv": ">=3.4",
         "consolidation/robo": ">=1.4"


### PR DESCRIPTION
## PHP has code deprecated in version 8.

Its change is for update `composer.json` in version compatible with php version 7.4 & 8.

## New version: 
```
"symfony/console": ">=4.4",
"symfony/process": ">=4.4",
```